### PR TITLE
Fix indentation in Bento values.yaml env section examples

### DIFF
--- a/charts/bento/values.yaml
+++ b/charts/bento/values.yaml
@@ -70,14 +70,14 @@ env: []
 #   value: bucket
 # - name: S3_BUCKET
 #   valueFrom:
-#   configMapKeyRef:
-#     name: s3-config
-#     key: bucket
+#     configMapKeyRef:
+#       name: s3-config
+#       key: bucket
 # - name: S3_TOKEN
 #   valueFrom:
-#   secretKeyRef:
-#     name: s3-secrets
-#     key: token
+#     secretKeyRef:
+#       name: s3-secrets
+#       key: token
 
 # Include ConfigMap objects
 configMapRefs: []


### PR DESCRIPTION
Super minor change. I've just noted that the indentation for the examples in the env section of the bento's `values.yaml` is not correct.

Fixing on the fly to avoid any possible issues in the future.

P.S. Thank you for maintaining these charts!