### PR TITLE
[add] Add initContainers to bento

### DIFF
--- a/charts/bento/Chart.yaml
+++ b/charts/bento/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bento
 description: "Bento is a declarative data streaming service that solves a wide range of data engineering problems with simple, chained, stateless processing steps. It implements transaction based resiliency with back pressure, so when connecting to at-least-once sources and sinks it's able to guarantee at-least-once delivery without needing to persist messages during transit."
 type: application
-version: 0.5.2
+version: 0.5.3
 appVersion: "1.2.0"
 icon: https://raw.githubusercontent.com/warpstreamlabs/bento/main/icon.png
 annotations:

--- a/charts/bento/templates/deployment.yaml
+++ b/charts/bento/templates/deployment.yaml
@@ -48,6 +48,10 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/bento/values.yaml
+++ b/charts/bento/values.yaml
@@ -101,6 +101,9 @@ extraVolumeMounts: []
 #   mountPath: "/etc/foo"
 #   readOnly: true
 
+# initContainers -- Init Containers to be added to the Bento Pods.
+initContainers: []
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
This PR adds the capability to specify `initContainers` within Bento's spec.

Tested with:

```
cd charts/bento
helm template .
```