### PR TITLE
[add] Enable streams mode

### DIFF
--- a/charts/bento/Chart.yaml
+++ b/charts/bento/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bento
 description: "Bento is a declarative data streaming service that solves a wide range of data engineering problems with simple, chained, stateless processing steps. It implements transaction based resiliency with back pressure, so when connecting to at-least-once sources and sinks it's able to guarantee at-least-once delivery without needing to persist messages during transit."
 type: application
-version: 0.6.0
+version: 0.7.0
 appVersion: "1.3.0"
 icon: https://raw.githubusercontent.com/warpstreamlabs/bento/main/icon.png
 annotations:

--- a/charts/bento/templates/deployment.yaml
+++ b/charts/bento/templates/deployment.yaml
@@ -56,6 +56,25 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.args }}
+          args:
+            {{- toYaml .Values.args | nindent 12 }}
+          {{- else }}
+          args:
+            - "-c"
+            - "/bento.yaml"
+            {{- if and .Values.streams.enabled .Values.streams.streamsConfigMap }}
+            - "streams"
+            {{- if eq .Values.streams.api.enable false }}
+            - "--no-api"
+            {{- end }}
+            - /streams/*.yaml
+            {{- end }}
+          {{- end }}
           {{- with .Values.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
@@ -87,6 +106,11 @@ spec:
             {{- with .Values.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- if and .Values.streams.enabled .Values.streams.streamsConfigMap }}
+            - name: streams
+              mountPath: "/streams"
+              readOnly: true
+            {{- end }}
           ports:
             {{- range .Values.service.ports }}
             - name: {{ .name }}
@@ -103,4 +127,9 @@ spec:
             name: {{ .Release.Name }}
         {{- with .Values.extraVolumes }}
           {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if and .Values.streams.enabled .Values.streams.streamsConfigMap }}
+        - name: streams
+          configMap:
+            name: {{ .Values.streams.streamsConfigMap }}
         {{- end }}

--- a/charts/bento/values.yaml
+++ b/charts/bento/values.yaml
@@ -64,6 +64,18 @@ config: |
     label: stdout
     stdout: {}
 
+# command -- Command replaces the entrypoint command of the docker
+command: []
+
+# args -- Override Bento's default arguments passed with command.
+args: []
+
+streams:
+  enabled: true
+  streamsConfigMap: ""
+  api:
+    enable: true
+
 # Define environment variables or load specific ones from ConfigMaps and Secrets
 # If all environment variables included in a ConfigMap or Secret need to be included, consider using a configMapRef or secretRef below
 env: []


### PR DESCRIPTION
This PR adds the capability to execute Bento in streams mode.

Tested with:

```
cd charts/bento
helm template .
```

Inspired by: https://github.com/redpanda-data/redpanda-connect-helm-chart