### PR TITLE
Remove Manyfold postgres dependency

### DIFF
--- a/charts/manyfold/Chart.yaml
+++ b/charts/manyfold/Chart.yaml
@@ -14,7 +14,3 @@ dependencies:
   - name: boilerplate
     version: 0.16.0
     repository: "https://self-hosters-by-night.github.io/helm-charts"
-  - name: postgres
-    version: 0.14.2
-    repository: "https://self-hosters-by-night.github.io/helm-charts"
-    


### PR DESCRIPTION
The image specified is manyfold-solo, which uses a sqlite database in /config, and an internal redis server, so an external postgres server isn't required.

I'm assuming that that's why this dependency is there, though I don't know my way around your charts or helm in general, so if this is wrong, just ignore it!